### PR TITLE
Support identify and push

### DIFF
--- a/WoopraSDK.xcodeproj/project.pbxproj
+++ b/WoopraSDK.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		6E8C76381F7535F900929E02 /* WTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8C76331F7535F900929E02 /* WTracker.swift */; };
 		6E8C76391F7535F900929E02 /* WEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8C76341F7535F900929E02 /* WEvent.swift */; };
 		6ECDA1EF1F7701F20053F3D6 /* DictionaryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECDA1EE1F7701F20053F3D6 /* DictionaryExtension.swift */; };
+		8A7768CA2BB2BEFB005164D2 /* WIdentify.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7768C92BB2BEFB005164D2 /* WIdentify.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,6 +42,7 @@
 		6E8C76331F7535F900929E02 /* WTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WTracker.swift; sourceTree = "<group>"; };
 		6E8C76341F7535F900929E02 /* WEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WEvent.swift; sourceTree = "<group>"; };
 		6ECDA1EE1F7701F20053F3D6 /* DictionaryExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryExtension.swift; sourceTree = "<group>"; };
+		8A7768C92BB2BEFB005164D2 /* WIdentify.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WIdentify.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,7 @@
 		6E8C76181F7535E000929E02 /* WoopraSDK */ = {
 			isa = PBXGroup;
 			children = (
+				8A7768C92BB2BEFB005164D2 /* WIdentify.swift */,
 				6E8C76191F7535E000929E02 /* WoopraSDK.h */,
 				6E8C76331F7535F900929E02 /* WTracker.swift */,
 				6E8C76301F7535F900929E02 /* WVisitor.swift */,
@@ -181,6 +184,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 6E8C760C1F7535E000929E02;
@@ -220,6 +224,7 @@
 				6E8C76381F7535F900929E02 /* WTracker.swift in Sources */,
 				6E8C76361F7535F900929E02 /* WPinger.swift in Sources */,
 				6ECDA1EF1F7701F20053F3D6 /* DictionaryExtension.swift in Sources */,
+				8A7768CA2BB2BEFB005164D2 /* WIdentify.swift in Sources */,
 				6E8C76351F7535F900929E02 /* WVisitor.swift in Sources */,
 				6E8C76371F7535F900929E02 /* WPropertiesContainer.swift in Sources */,
 			);

--- a/WoopraSDK/WIdentify.swift
+++ b/WoopraSDK/WIdentify.swift
@@ -12,7 +12,10 @@ public class WIdentify {
     }
     
     func run() {
-        let url = URL(string: wIdnetifyEndPoint)!
+        guard let url = URL(string: wIdnetifyEndPoint) else {
+            print("Invalid URL")
+            return
+        }
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         
@@ -21,7 +24,7 @@ public class WIdentify {
             "cookie": tracker.visitor.cookie,
             "app": "ios",
             "response": "xml",
-            "os": "ios",
+            "os": "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)",
             "timeout": Int(
                 tracker.idleTimeout * 1000
             ),

--- a/WoopraSDK/WIdentify.swift
+++ b/WoopraSDK/WIdentify.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+public class WIdentify {
+    
+    private let wIdnetifyEndPoint = "https://www.woopra.com/track/identify"
+    private let tracker: WTracker
+    
+    init(
+        tracker: WTracker
+    ) {
+        self.tracker = tracker
+    }
+    
+    func run() {
+        let url = URL(string: wIdnetifyEndPoint)!
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        
+        var requestBody: [String: Any] = [
+            "host": tracker.domain ?? "",
+            "cookie": tracker.visitor.cookie,
+            "app": "ios",
+            "response": "xml",
+            "os": "ios",
+            "timeout": Int(
+                tracker.idleTimeout * 1000
+            ),
+        ]
+        
+        let visitorProperties = tracker.visitor.properties
+        for ( key, value ) in visitorProperties {
+            requestBody["cv_\(key)"] = value
+        }
+        
+        urlRequest.httpBody = try? JSONSerialization.data(
+            withJSONObject: requestBody,
+            options: []
+        )
+        urlRequest.setValue(
+            "application/json",
+            forHTTPHeaderField: "Content-Type"
+        )
+        
+        print("Request Body: \(requestBody)")
+        
+        let task = URLSession.shared.dataTask(with: urlRequest) {
+            (
+                data,
+                response,
+                error
+            ) in
+            if let error = error {
+                print(
+                    "Got error: \(error)"
+                )
+                return
+            }
+            
+            if let httpResponse = response as? HTTPURLResponse {
+                print(
+                    "Response: \(httpResponse.statusCode)"
+                )
+            }
+        }
+        
+        task.resume()
+    }
+}
+
+extension String {
+    var urlEncoded: String {
+        return addingPercentEncoding(
+            withAllowedCharacters: .urlQueryAllowed
+        ) ?? ""
+    }
+}

--- a/WoopraSDK/WTracker.swift
+++ b/WoopraSDK/WTracker.swift
@@ -139,4 +139,12 @@ public class WTracker: WPropertiesContainer {
     public func trackEvent(named: String) {
         self.trackEvent(WEvent(name: named))
     }
+    
+    // MARK: - Methods
+    public func push() {
+        let identify = WIdentify(tracker: self)
+        DispatchQueue.global(qos: .utility).async {
+            identify.run()
+        }
+    }
 }


### PR DESCRIPTION
### Purpose:
Support identify and push.

### Changes:
1. Apply the same logic from `woopra-android-sdk` but use HTTP POST to make the request.
2. Register `WIdentify.swift` as a output resources

### How To Verify it:
1. Config tracker first
```
    WTracker.shared.domain = "<your-domain>"
    WTracker.shared.visitor.add(property: "name", value: "JH Lin")
    WTracker.shared.visitor.add(property: "email", value: "jh.lin@company.com")
```

2. Use the following code to update properties(must use a different value).

```
    WTracker.shared.visitor.add(property: "name", value: "name-new")
    WTracker.shared.visitor.add(property: "email", value: "example-new@company.com")
    WTracker.shared.push()
```
3. Check the activity
![image](https://github.com/Woopra/Woopra-iOS/assets/10951814/04c4ace2-e7cf-475d-a36b-4c8c22c5ea8e)
![image](https://github.com/Woopra/Woopra-iOS/assets/10951814/d76544b2-ec83-4455-b315-3c8b32e6f953)


