### PR TITLE
Use HTTP POST in the Tracker

### DIFF
--- a/WoopraSDK/WTracker.swift
+++ b/WoopraSDK/WTracker.swift
@@ -73,8 +73,11 @@ public class WTracker: WPropertiesContainer {
             return
         }
         
-        let url = URL(string: wEventEndpoint)!
-        let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true)
+        guard let url = URL(string: wEventEndpoint) else {
+             print("Invalid URL")
+             return
+         }
+        
         var queryItems: [NSURLQueryItem] = [
             NSURLQueryItem(name: "app", value: "ios"),
             NSURLQueryItem(name: "host", value: domain),
@@ -110,30 +113,48 @@ public class WTracker: WPropertiesContainer {
             }
         }
         
-        components?.queryItems = queryItems as [URLQueryItem]
-        let requestUrl = components?.url
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
-        if let url = requestUrl {
-            let request = URLRequest(url: url)
-            let task = URLSession.shared.dataTask(with: request, completionHandler: { (data, response, error) in
-                #if DEBUG
-                // check for errors
-                guard error == nil else {
-                    print("error")
-                    print(error!)
-                    return
-                }
-                
-                guard let responseData = data else {
-                    print("Error: did not receive data")
-                    return
-                }
-
-                print(responseData.debugDescription)
-                #endif
-            })
-            task.resume()
+        // Convert queryItems to a dictionary
+        let parameters = queryItems.reduce(into: [String: String]()) { result, item in
+            result[item.name] = item.value
         }
+        if let jsonString = try? JSONSerialization.data(withJSONObject: parameters, options: []) {
+            request.httpBody = jsonString
+            #if DEBUG
+            // Print the request body
+            if let requestBody = String(data: jsonString, encoding: .utf8) {
+                print("Request Body:")
+                print(requestBody)
+            } else {
+                print("Failed to convert request body to string")
+            }
+            #endif
+        } else {
+            print("Failed to serialize parameters to JSON")
+            return
+        }
+        
+        let task = URLSession.shared.dataTask(with: request, completionHandler: { (data, response, error) in
+            if let error = error {
+                print("Error: \(error.localizedDescription)")
+                return
+            }
+            
+            guard data != nil else {
+                print("Error: No response data")
+                return
+            }
+            
+            #if DEBUG
+            if let httpResponse = response as? HTTPURLResponse {
+                print("Response: \(httpResponse.statusCode)")
+            }
+            #endif
+        })
+        task.resume()
     }
     
     public func trackEvent(named: String) {

--- a/WoopraSDK/WTracker.swift
+++ b/WoopraSDK/WTracker.swift
@@ -126,8 +126,7 @@ public class WTracker: WPropertiesContainer {
             #if DEBUG
             // Print the request body
             if let requestBody = String(data: jsonString, encoding: .utf8) {
-                print("Request Body:")
-                print(requestBody)
+                print("Request Body: \(requestBody)")
             } else {
                 print("Failed to convert request body to string")
             }


### PR DESCRIPTION
### Purpose:
Change to use HTTP POST in the WTracker

### Changes:
Use the HTTP POST instead of the GET method to send the request.

### Expected Behavior:
The tracker is still functioning as it did before.

### How To Verify it:
Start a track event and check if it appears on the dashboard.
```
     let event = WEvent.event(name: "event-name")
     event.add(property: "view", value: "view-value")
     WTracker.shared.trackEvent(event)
```

