### PR TITLE
Prepare for publishing to Cocoapod

### DIFF
--- a/Woopra-iOS.podspec
+++ b/Woopra-iOS.podspec
@@ -6,8 +6,9 @@ Pod::Spec.new do |s|
 
   s.homepage     = "http://woopra.com/"
   s.license      = "MIT"
-  s.author             = "Woopra"
+  s.author       = "Woopra"
   s.platform     = :ios, "10.0"
+  s.swift_versions = ['4.0']
 
   s.source       = { :git => "https://github.com/Woopra/Woopra-iOS.git", :tag => "#{s.version}" }
   s.source_files = "WoopraSDK", "WoopraSDK/**/*.{h,m,swift}"


### PR DESCRIPTION
### Purpose:
Before publishing a new version to Cocoapods, let's check if there are any configuration requirements.
### Changes:
After running `pod lib lint`, a warning appears indicating that no Swift version was specified. To address this issue, we added `s.swift_versions = ['4.0']` to specify the Swift version as 4.0. Support for Swift 4.0 was added in Xcode 9.0.

### Expected Behavior:
We can publish a new version to Cocoapods.

### How To Verify it:
We need to initiate the release process to verify it.

