### PR TITLE
Expose classes and members to Objective-C

### DIFF
--- a/WoopraSDK/WEvent.swift
+++ b/WoopraSDK/WEvent.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@objcMembers
 public class WEvent: WPropertiesContainer {
     
     public init(name: String) {

--- a/WoopraSDK/WIdentify.swift
+++ b/WoopraSDK/WIdentify.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class WIdentify {
+internal class WIdentify {
     
     private let wIdnetifyEndPoint = "https://www.woopra.com/track/identify"
     private let tracker: WTracker

--- a/WoopraSDK/WPropertiesContainer.swift
+++ b/WoopraSDK/WPropertiesContainer.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@objcMembers
 public class WPropertiesContainer: NSObject {
     var properties: [String: String] = [:]
     

--- a/WoopraSDK/WTracker.swift
+++ b/WoopraSDK/WTracker.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2017 Woopra. All rights reserved.
 //
 
+@objcMembers
 public class WTracker: WPropertiesContainer {
     
     // MARK: - Public properties

--- a/WoopraSDK/WVisitor.swift
+++ b/WoopraSDK/WVisitor.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2017 Woopra. All rights reserved.
 //
 
+@objcMembers
 public class WVisitor: WPropertiesContainer {
     
     public var cookie = ""


### PR DESCRIPTION
### Purpose:
Exposing swift classes and members to Objective-C. 
### Changes:
1. Adding `@objcMembers` to public classes.
2. Make `WIdentify` an internal class as it can only be accessed from `WTracker`

### Expected Behavior:
1. Public methods can be accessed in an Objective-C code.
2. `WIdentify` is not available for public access.

### How To Verify it:
1. Trying to use `WIdentify` directly, there should be a compile error of "cannot find WIdentify" or "undeclared identifier WIdentify"
2. Trying to call API in Objective-C, you can directly add the following code in `AppDelegate.m` in `AIQUA` project. Remember to import the headers in the file:
```
#import "WoopraSDK/WoopraSDK.h"
#import "WoopraSDK/WoopraSDK-Swift.h"
```

- Set domain and visitor
```
[WTracker shared].domain = @"<your-domain>";
[[WTracker shared].visitor addWithProperty:@"name" value:@"John Doe"];
[[WTracker shared].visitor addWithProperty:@"email" value:@"JohnDoe@appier.com"];
```
-  Track an event
```
WEvent* event = [WEvent eventWithName:@"app_launch"];
[event addWithProperty:@"event-name" value:@"app_launch"];
[[WTracker shared] trackEvent:event];
```
- Identify and push
```
[[WTracker shared].visitor addWithProperty:@"name" value:@"John Doe-identified"];
[[WTracker shared] push];
```
- Check if you can see the events on the dashboard.

