### PR TITLE
chore: modify default idle timeout and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ WTracker.shared.referer = <REFERRER_STRING>
 
 #### Idle Timeout
 
-You can update your idle timeout (default: 30 seconds) by updating the timeout property in your WTracker instance:
+You can update your idle timeout (default: 5 minutes) by updating the timeout property in your WTracker instance:
 
 ``` swift
-WTracker.shared.idleTimeout = 30
+WTracker.shared.idleTimeout = 300
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -71,12 +71,6 @@ When the app loads, you should load the Woopra Tracker and configure it.
 WTracker.shared.domain = "mybusiness.com"
 ```
 
-You can update your idle timeout (default: 60 seconds) by updating the timeout property in your WTracker instance:
-
-``` swift
-WTracker.shared.idleTimeout = 30
-```
-
 ### Event Tracking
 
 To track an `appview` event:
@@ -104,3 +98,28 @@ You can then send an identify call without tracking an event by using the push m
 ``` swift
 WTracker.shared.push()
 ```
+
+## Advanced Settings
+
+To add referrer information, timestamp, and other track request properties, look at the `WoopraTracker` and `WoopraEvent` class public methods for an exhaustive list of setter methods.  Here are some common examples:
+
+### Tracker Settings
+
+#### Track Referrer
+
+To add referrer information, set the referer property in your WTracker instance:
+
+``` swift
+WTracker.shared.referer = <REFERRER_STRING>
+```
+
+#### Idle Timeout
+
+You can update your idle timeout (default: 30 seconds) by updating the timeout property in your WTracker instance:
+
+``` swift
+WTracker.shared.idleTimeout = 30
+```
+
+> [!NOTE]
+> The idle timeout is in seconds.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ WTracker.shared.referer = <REFERRER_STRING>
 You can update your idle timeout (default: 5 minutes) by updating the timeout property in your WTracker instance:
 
 ``` swift
-WTracker.shared.idleTimeout = 300
+WTracker.shared.idleTimeout = 360
 ```
 
 > [!NOTE]

--- a/WoopraSDK/WTracker.swift
+++ b/WoopraSDK/WTracker.swift
@@ -31,13 +31,13 @@ public class WTracker: WPropertiesContainer {
             }
         }
     }
-    
-    private static let defaultIdleTimeout: TimeInterval = 60.0
-    private var _idleTimeout: TimeInterval = defaultIdleTimeout
-    
+
     // visit’s referring URL, Woopra servers will match the URL against a database of referrers and will generate a referrer type and search terms when applicable. The referrers data will be automatically accessible from the Woopra clients.
-    public var referer: String?
+    @objc dynamic public var referer: String?
     
+    private static let defaultIdleTimeout: TimeInterval = 30.0
+    private var _idleTimeout: TimeInterval = defaultIdleTimeout
+
     // MARK: - Private properties
     private let wEventEndpoint = "https://www.woopra.com/track/ce/"
     

--- a/WoopraSDK/WTracker.swift
+++ b/WoopraSDK/WTracker.swift
@@ -35,7 +35,7 @@ public class WTracker: WPropertiesContainer {
     // visit’s referring URL, Woopra servers will match the URL against a database of referrers and will generate a referrer type and search terms when applicable. The referrers data will be automatically accessible from the Woopra clients.
     @objc dynamic public var referer: String?
     
-    private static let defaultIdleTimeout: TimeInterval = 300.0
+    private static let defaultIdleTimeout: TimeInterval = 300
     private var _idleTimeout: TimeInterval = defaultIdleTimeout
 
     // MARK: - Private properties

--- a/WoopraSDK/WTracker.swift
+++ b/WoopraSDK/WTracker.swift
@@ -35,7 +35,7 @@ public class WTracker: WPropertiesContainer {
     // visit’s referring URL, Woopra servers will match the URL against a database of referrers and will generate a referrer type and search terms when applicable. The referrers data will be automatically accessible from the Woopra clients.
     @objc dynamic public var referer: String?
     
-    private static let defaultIdleTimeout: TimeInterval = 30.0
+    private static let defaultIdleTimeout: TimeInterval = 300.0
     private var _idleTimeout: TimeInterval = defaultIdleTimeout
 
     // MARK: - Private properties

--- a/WoopraSDKTests/WTrackerTests.swift
+++ b/WoopraSDKTests/WTrackerTests.swift
@@ -18,7 +18,7 @@ final class WTrackerTests: XCTestCase {
         // assert
         XCTAssertNil(tracker.domain)
         XCTAssertNotNil(tracker.visitor)
-        XCTAssertEqual(tracker.idleTimeout, 60)
+        XCTAssertEqual(tracker.idleTimeout, 300)
         XCTAssertNil(tracker.referer)
     }
 }


### PR DESCRIPTION
This PR is to update the default idle timeout to 5 minutes. Besides, information about setting referrer is updated in README.